### PR TITLE
Update numpy version to correct np.float error

### DIFF
--- a/nlb_tools/make_tensors.py
+++ b/nlb_tools/make_tensors.py
@@ -1355,10 +1355,12 @@ def _save_h5_r(data_dict, h5obj, dlen):
             _save_h5_r(val, h5group, dlen)
         else:
             if val.dtype == 'object':
-                sub_dtype = f'float{dlen}' if val[0].dtype == np.float else f'int{dlen}' if val[0].dtype == np.int else val[0].dtype
+                sub_dtype = f'float{dlen}' if np.issubdtype(val[0].dtype, np.floating) else \
+                    f'int{dlen}' if np.issubdtype(val[0].dtype, np.integer) else val[0].dtype
                 dtype = h5py.vlen_dtype(sub_dtype)
             else:
-                dtype = f'float{dlen}' if val.dtype == np.float else f'int{dlen}' if val.dtype == np.int else val.dtype
+                dtype = f'float{dlen}' if np.issubdtype(val.dtype, np.floating) else \
+                    f'int{dlen}' if np.issubdtype(val.dtype, np.integer) else val.dtype
             h5obj.create_dataset(key, data=val, dtype=dtype)
             
 def h5_to_dict(h5obj):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "nlb_tools"
-version = "0.0.1"
+version = "0.0.2"
 license = "MIT"
 description = "Python tools for participating in Neural Latents Benchmark '21"
 authors = [

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='nlb_tools',
-    version='0.0.1',
+    version='0.0.2',
     packages=find_packages(),
     install_requires=[
         'pandas>=1.0.0,<=1.3.4',

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ setup(
     install_requires=[
         'pandas>=1.0.0,<=1.3.4',
         'scipy',
-        'numpy<1.20',
+        'numpy',
         'scikit-learn',
         'h5py<4,>=2.9',
         'pynwb',

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ setup(
     install_requires=[
         'pandas>=1.0.0,<=1.3.4',
         'scipy',
-        'numpy',
+        'numpy<1.20',
         'scikit-learn',
         'h5py<4,>=2.9',
         'pynwb',


### PR DESCRIPTION
`numpy` 1.20 removed `np.float` functionality (used in `make_tensors.py`) in favor of `float` and now raises an error. Modified setup to use versions <1.20.